### PR TITLE
Triton v2.3.1 no downloads

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/intel_xpu_backend"]
 	path = third_party/intel_xpu_backend
-	url = http://github.com/intel/intel-xpu-backend-for-triton
+	url = https://github.com/intel/intel-xpu-backend-for-triton
 [submodule "third_party/amd_hip_backend"]
 	path = third_party/amd_hip_backend
 	url = https://github.com/ROCmSoftwarePlatform/triton

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 # Options
 option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
+option(TRITON_BUILD_UT "Build C++ Triton Unit Tests" ON)
 set(TRITON_CODEGEN_BACKENDS "" CACHE STRING "Enable different codegen backends")
 
 # Ensure Python3 vars are set correctly
@@ -277,4 +278,6 @@ endif()
 
 add_subdirectory(test)
 
-add_subdirectory(unittest)
+if(TRITON_BUILD_UT)
+  add_subdirectory(unittest)
+endif()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "pybind11 >= 2.11.1"]
 
 # We're incrementally switching from autopep8 to ruff.
 [tool.autopep8]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1", "pybind11 >= 2.11.1"]
+requires = ["setuptools>=40.8.0", "wheel", "ninja>=1.11.1", "pybind11 >= 2.11.1"]
 
 # We're incrementally switching from autopep8 to ruff.
 [tool.autopep8]

--- a/python/setup.py
+++ b/python/setup.py
@@ -246,6 +246,7 @@ class CMakeBuild(build_ext):
             os.makedirs(self.build_temp)
         # python directories
         python_include_dir = sysconfig.get_path("platinclude")
+        build_ut = os.environ.get("TRITON_BUILD_UT", "OFF").upper()
         cmake_args = [
             "-G",
             "Ninja",  # Ninja is much faster than make
@@ -256,6 +257,7 @@ class CMakeBuild(build_ext):
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DTRITON_BUILD_TUTORIALS=OFF",
             "-DTRITON_BUILD_PYTHON_MODULE=ON",
+            f"-DTRITON_BUILD_UT:bool={build_ut}",
             "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,

--- a/python/setup.py
+++ b/python/setup.py
@@ -97,6 +97,7 @@ def get_llvm_package_info():
 
 
 def open_url(url):
+    raise ValueError(f"Attempting to download {url}")
     user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0'
     headers = {
         'User-Agent': user_agent,
@@ -116,6 +117,7 @@ def get_thirdparty_packages(triton_cache_path):
         version_file_path = os.path.join(package_dir, "version.txt")
         if p.syspath_var_name not in os.environ and\
            (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
+            raise ValueError(f"Attempting to download {p.name}, set {p.syspath_var_name}")
             try:
                 shutil.rmtree(package_root_dir)
             except Exception:
@@ -138,6 +140,8 @@ def get_thirdparty_packages(triton_cache_path):
 
 
 def download_and_copy(src_path, variable, version, url_func):
+    # disable download
+    return
     if variable in os.environ:
         return
     base_dir = os.path.dirname(__file__)

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,6 +12,7 @@ from distutils.command.clean import clean
 from pathlib import Path
 from typing import NamedTuple
 
+import pybind11
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
@@ -105,7 +106,7 @@ def open_url(url):
 
 
 def get_thirdparty_packages(triton_cache_path):
-    packages = [get_pybind11_package_info(), get_llvm_package_info()]
+    packages = [get_llvm_package_info()]
     thirdparty_cmake_args = []
     for p in packages:
         package_root_dir = os.path.join(triton_cache_path, p.package)
@@ -261,6 +262,7 @@ class CMakeBuild(build_ext):
             "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
+            f"-DPYBIND11_INCLUDE_DIR={pybind11.get_include()}",
         ]
         if lit_dir is not None:
             cmake_args.append("-DLLVM_EXTERNAL_LIT=" + lit_dir)

--- a/python/triton/common/backend.py
+++ b/python/triton/common/backend.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 import os
 import re
+import shutil
 import subprocess
 import traceback
 from typing import Dict
@@ -109,6 +110,9 @@ def _path_to_binary(binary: str):
     base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
     paths = [
         os.environ.get(f"TRITON_{binary.upper()}_PATH", ""),
+        os.path.join(os.environ.get("CUDA_HOME", "/usr/local/cuda"), "bin", binary),
+        os.path.join(os.environ.get("ROCM_PATH", "/opt/rocm"), "bin", binary),
+        shutil.which(binary) or "",
         os.path.join(base_dir, "third_party", "cuda", "bin", binary)
     ]
 


### PR DESCRIPTION
- Add cmake option TRITON_BUILD_UNITTEST
- Include pybind11 via [build-system] requires
- use https in git submodules 
- Locate ptax, cuobjdump, nvdisasm in PATH, CUDA_HOME/bin
- Disable downloads of CUDA binaries and llvm
- Use system cmake